### PR TITLE
docs: clarify prerequisites and env config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 GITHUB_TOKEN=your_github_token_here
+API_KEY=your_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,5 @@ local_settings.py
 *.db
 *.sqlite3
 
-# Firefox repo (explicitly excluded) 
+# Firefox repo (explicitly excluded)
+firefox-repo/

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ This repository contains a data analysis and exploration project using Jupyter n
 
 ## Prerequisites
 
-Before running this project, you need to:
+Before running this project, ensure you have:
 
-1. Clone this repository
-2. Clone the Firefox repository (required for analysis):
+1. Python 3.8 or higher installed
+2. Git installed
+3. Clone this repository
+4. Clone the Firefox repository (required for analysis):
 ```bash
 git clone https://github.com/mozilla/gecko-dev.git firefox-repo
 ```
@@ -61,6 +63,7 @@ jupyter notebook
 
 ## Environment Variables
 Create a `.env` file based on `.env.example` and fill in your credentials:
+- `GITHUB_TOKEN`: Token used for GitHub API access
 - `API_KEY`: Your API key (if needed)
 - Add other environment variables as needed
 


### PR DESCRIPTION
## Summary
- document Python 3.8+ and Git requirements in README
- mention `GITHUB_TOKEN` in environment variable section
- sync `.env.example` with README
- ignore `firefox-repo/` in `.gitignore`

## Testing
- `pip install -r requirements.txt` *(fails: BackendUnavailable: Cannot import 'setuptools.build_meta')*

------
https://chatgpt.com/codex/tasks/task_e_6845c020f760833393abca609da41933